### PR TITLE
Fix str/bytes type around events

### DIFF
--- a/tests/docker/mock_docker.py
+++ b/tests/docker/mock_docker.py
@@ -97,4 +97,4 @@ def get_event(type, action, container_id, attributes):
             ATTRIBUTES: attributes
         },
         TIME: int(time.time())
-    })
+    }).encode("utf-8")

--- a/tests/docker/test_events.py
+++ b/tests/docker/test_events.py
@@ -101,7 +101,7 @@ class TestEvents(unittest.TestCase):
 
     def test_absent_cpu_label(self):
         test_context = TestContext()
-        unknown_event = get_event(CONTAINER, CREATE, uuid.uuid4(), {WORKLOAD_TYPE_LABEL_KEY: STATIC})
+        unknown_event = get_event(CONTAINER, CREATE, "unknown", {WORKLOAD_TYPE_LABEL_KEY: STATIC})
         event_iterable = MockEventProvider([unknown_event])
         manager = EventManager(event_iterable, test_context.get_event_handlers())
 

--- a/titus_isolate/docker/event_manager.py
+++ b/titus_isolate/docker/event_manager.py
@@ -29,6 +29,7 @@ class EventManager:
 
     def __process_events(self):
         for event in self.__events:
+            event = event.decode("utf-8")
             for event_handler in self.__event_handlers:
                 try:
                     event_handler.handle(json.loads(event))


### PR DESCRIPTION
Events from Docker are of typey 'bytes'.  Tests now produce events of
this type as well