### PR TITLE
Fix auto-enable of titus-isolate.service

### DIFF
--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -7,8 +7,8 @@ RUN apt update && apt install -y \
     dh-virtualenv \
     python3-all \
     python3-pip
-COPY rules /rules
-COPY build-deb.sh /build-deb.sh
-COPY titus-isolate.service /titus-isolate.service
+COPY build-deb.sh /
+COPY rules /
+COPY titus-isolate.service /
 WORKDIR /src
 CMD ["/build-deb.sh"]

--- a/release/rules
+++ b/release/rules
@@ -1,7 +1,11 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with python-virtualenv,systemd
+	dh $@ --with systemd,python-virtualenv
 
 override_dh_virtualenv:
 	dh_virtualenv --python /usr/bin/python3 --no-test
+override_dh_installinit:
+	echo "Supressing installinit, unneeded for systemd only packages"
+override_dh_systemd_start:
+	dh_systemd_start --restart-after-upgrade

--- a/release/titus-isolate.service
+++ b/release/titus-isolate.service
@@ -9,4 +9,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-Alias=titus-isolate.service
+Alias=titus-isolate


### PR DESCRIPTION
See my answer here for why this change was needed: https://unix.stackexchange.com/a/479945/319147