### PR TITLE
Detect exit of the workload manager thread and exit the application

### DIFF
--- a/startup/titus-isolate
+++ b/startup/titus-isolate
@@ -1,4 +1,7 @@
-#!/usr/bin/env python3
+#!/usr/share/python/titus-isolate/bin/python
+import os
+from threading import Thread
+
 import click
 import docker
 from titus_isolate.api.status import app, set_wm
@@ -45,10 +48,25 @@ def main(admin_port):
     log.info("Isolating currently running workloads...")
     workload_manager.add_workloads(get_current_workloads(docker_client))
 
-    log.info("Startup complete, waiting for events...")
-
     # Starting the HTTP server blocks exit forever
-    app.run(host="0.0.0.0", debug=False, port=admin_port)
+    log.info("Starting HTTP server")
+    __start_http_server(admin_port)
+
+    log.info("Startup complete, waiting for events...")
+    workload_manager.join()
+
+    log.error("The workload manager should never exit, yet here we are...")
+    os._exit(42)
+
+
+def __start_http_server(admin_port):
+    # Starting the HTTP server blocks exit forever
+    def __run_http_server():
+        app.run(host="0.0.0.0", debug=False, port=admin_port)
+
+    http_server_thread = Thread(target=__run_http_server)
+    http_server_thread.daemon = True
+    http_server_thread.start()
 
 
 if __name__ == "__main__":

--- a/tests/isolate/test_workload_manager.py
+++ b/tests/isolate/test_workload_manager.py
@@ -3,7 +3,7 @@ import unittest
 import uuid
 
 from tests.docker.mock_docker import MockDockerClient, MockContainer
-from tests.utils import wait_until
+from tests.utils import wait_until, config_logs
 from titus_isolate.docker.constants import STATIC, BURST
 from titus_isolate.isolate.cpu import assign_threads
 from titus_isolate.isolate.detect import get_cross_package_violations, get_shared_core_violations
@@ -13,6 +13,7 @@ from titus_isolate.model.processor.utils import DEFAULT_TOTAL_THREAD_COUNT
 from titus_isolate.model.workload import Workload
 from titus_isolate.utils import get_logger
 
+config_logs(logging.DEBUG)
 log = get_logger(logging.DEBUG)
 
 


### PR DESCRIPTION
We deployed the current code and after dumping all threads we saw cases where the workload_manager worker thread was no longer running and processing the queue.  That is bad.  Now if we detect exit of that thread we exit the application.