### PR TITLE
Turn off CFS quota when setting cpusets as kernel bug workaround

### DIFF
--- a/tests/api/test_status.py
+++ b/tests/api/test_status.py
@@ -3,20 +3,25 @@ import unittest
 import uuid
 
 from tests.cgroup.mock_cgroup_manager import MockCgroupManager
+from tests.config.test_property_provider import TestPropertyProvider
 from tests.docker.mock_docker import MockDockerClient, MockContainer, MockEventProvider
 from titus_isolate.api import status
 from titus_isolate.api.status import set_wm, get_workloads, get_violations, get_wm_status, set_em
+from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.docker.constants import STATIC
 from titus_isolate.docker.event_manager import EventManager
 from titus_isolate.isolate.workload_manager import WorkloadManager
 from titus_isolate.model.processor.config import get_cpu
 from titus_isolate.model.processor.utils import DEFAULT_PACKAGE_COUNT, DEFAULT_CORE_COUNT, DEFAULT_THREAD_COUNT
 from titus_isolate.model.workload import Workload
+from titus_isolate.utils import override_config_manager
 
 
 class TestStatus(unittest.TestCase):
 
     def test_get_workloads_endpoint(self):
+        override_config_manager(ConfigManager(TestPropertyProvider({})))
+
         cpu = get_cpu()
         thread_count = 2
         workload_id = str(uuid.uuid4())

--- a/tests/cgroup/mock_cgroup_manager.py
+++ b/tests/cgroup/mock_cgroup_manager.py
@@ -3,11 +3,12 @@ from titus_isolate.cgroup.cgroup_manager import CgroupManager
 
 
 class MockCgroupManager(CgroupManager):
+
     def __init__(self):
         self.container_update_map = {}
         self.container_update_counts = {}
 
-    def set_cpuset(self, container_name, thread_ids):
+    def set_cpuset(self, container_name, thread_ids, timeout):
         log.debug("Updating container: '{}' to cpuset: '{}'".format(container_name, thread_ids))
         self.container_update_map[container_name] = thread_ids
 
@@ -16,3 +17,5 @@ class MockCgroupManager(CgroupManager):
         else:
             self.container_update_counts[container_name] += 1
 
+    def set_quota(self, container_name, value, timeout):
+        log.debug("Updating container: '{}' to quota: '{}'".format(container_name, value))

--- a/tests/cgroup/test_utils.py
+++ b/tests/cgroup/test_utils.py
@@ -5,7 +5,8 @@ import unittest
 
 from tests.config.test_property_provider import TestPropertyProvider
 from tests.utils import config_logs
-from titus_isolate.cgroup.utils import get_cpuset_path_from_list, get_cpuset_path_from_file, wait_for_file_to_exist
+from titus_isolate.cgroup.utils import _get_cgroup_path_from_list, wait_for_file_to_exist, CPUSET, \
+    get_cgroup_path_from_file
 from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.utils import override_config_manager
 
@@ -31,22 +32,22 @@ expected_path = "/containers.slice/d6d503e8-2223-4ad2-9133-ca6cce6a80d0/ed561353
 class TestUtils(unittest.TestCase):
 
     def test_parse_cpuset_path_success(self):
-        self.assertEqual(expected_path, get_cpuset_path_from_list(test_input))
+        self.assertEqual(expected_path, _get_cgroup_path_from_list(test_input, CPUSET))
 
     def test_parse_cpuset_path_failure(self):
         # Note that the cpuset line is missing when compared to the success case
         cgroups_list = copy.deepcopy(test_input)
         cgroups_list.pop(7)
-        self.assertEqual(None, get_cpuset_path_from_list(cgroups_list))
+        self.assertEqual(None, _get_cgroup_path_from_list(cgroups_list, CPUSET))
 
     def test_parse_from_file(self):
         override_config_manager(ConfigManager(TestPropertyProvider({})))
         dir = os.path.dirname(os.path.abspath(__file__))
-        self.assertEqual(expected_path, get_cpuset_path_from_file(dir + "/test_cgroup_file"))
+        self.assertEqual(expected_path, get_cgroup_path_from_file(dir + "/test_cgroup_file", CPUSET, 0))
 
     def test_wait_for_file_to_exist(self):
         override_config_manager(ConfigManager(TestPropertyProvider({})))
-        with self.assertRaises(TimeoutError) as context:
-            wait_for_file_to_exist("/tmp/foo")
+        with self.assertRaises(TimeoutError):
+            wait_for_file_to_exist("/tmp/foo", 0.1)
 
-        wait_for_file_to_exist(__file__)
+        wait_for_file_to_exist(__file__, 0.1)

--- a/tests/cgroup/test_utils.py
+++ b/tests/cgroup/test_utils.py
@@ -5,8 +5,8 @@ import unittest
 
 from tests.config.test_property_provider import TestPropertyProvider
 from tests.utils import config_logs
-from titus_isolate.cgroup.utils import _get_cgroup_path_from_list, wait_for_file_to_exist, CPUSET, \
-    get_cgroup_path_from_file
+from titus_isolate.cgroup.utils import _get_cgroup_path_from_list, CPUSET, get_cgroup_path_from_file, \
+    _wait_for_file_to_exist
 from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.utils import override_config_manager
 
@@ -43,11 +43,18 @@ class TestUtils(unittest.TestCase):
     def test_parse_from_file(self):
         override_config_manager(ConfigManager(TestPropertyProvider({})))
         dir = os.path.dirname(os.path.abspath(__file__))
-        self.assertEqual(expected_path, get_cgroup_path_from_file(dir + "/test_cgroup_file", CPUSET, 0))
+        self.assertEqual(expected_path, get_cgroup_path_from_file(dir + "/test_cgroup_file", CPUSET))
 
     def test_wait_for_file_to_exist(self):
         override_config_manager(ConfigManager(TestPropertyProvider({})))
         with self.assertRaises(TimeoutError):
-            wait_for_file_to_exist("/tmp/foo", 0.1)
+            _wait_for_file_to_exist("/tmp/foo", 0.1)
 
-        wait_for_file_to_exist(__file__, 0.1)
+        _wait_for_file_to_exist(__file__, 0.1)
+
+    def test_wait_for_file_check_raises(self):
+        def __raise_for_testing():
+            raise RuntimeError("Test error")
+
+        with self.assertRaises(RuntimeError):
+            _wait_for_file_to_exist("/tmp/foo", 0.1, __raise_for_testing)

--- a/titus_isolate/cgroup/cgroup_manager.py
+++ b/titus_isolate/cgroup/cgroup_manager.py
@@ -4,5 +4,9 @@ from abc import abstractmethod
 class CgroupManager:
 
     @abstractmethod
-    def set_cpuset(self, container_name, thread_ids):
+    def set_cpuset(self, container_name, thread_ids, timeout):
+        pass
+
+    @abstractmethod
+    def set_quota(self, container_name, thread_ids, timeout):
         pass

--- a/titus_isolate/cgroup/file_cgroup_manager.py
+++ b/titus_isolate/cgroup/file_cgroup_manager.py
@@ -1,14 +1,18 @@
 from titus_isolate import log
 from titus_isolate.cgroup.cgroup_manager import CgroupManager
-from titus_isolate.cgroup.utils import set_cpuset
+from titus_isolate.cgroup.utils import set_cpuset, set_quota
 
 
 class FileCgroupManager(CgroupManager):
 
-    def set_cpuset(self, container_name, thread_ids):
+    def set_cpuset(self, container_name, thread_ids, timeout):
         thread_ids_str = self.__get_thread_ids_str(thread_ids)
         log.info("updating workload: '{}' to cpuset.cpus: '{}'".format(container_name, thread_ids_str))
-        set_cpuset(container_name, thread_ids_str)
+        set_cpuset(container_name, thread_ids_str, timeout)
+
+    def set_quota(self, container_name, value, timeout):
+        log.info("updating workload: '{}' to cpu.cfs_quota_us: '{}'".format(container_name, value))
+        set_quota(container_name, value, timeout)
 
     @staticmethod
     def __get_thread_ids_str(thread_ids):

--- a/titus_isolate/cgroup/utils.py
+++ b/titus_isolate/cgroup/utils.py
@@ -2,59 +2,91 @@ import os
 import time
 
 from titus_isolate import log
-from titus_isolate.config.constants import DEFAULT_WAIT_CGROUP_FILE_SEC, WAIT_CGROUP_FILE_KEY
-from titus_isolate.utils import get_config_manager
 
 ROOT_CGROUP_PATH = "/sys/fs/cgroup"
 ROOT_MESOS_INFO_PATH = "/var/lib/titus-inits"
 
+CPUSET = "cpuset"
+CPU_CPUACCT = "cpu,cpuacct"
 
-def wait_for_file_to_exist(file_path):
+
+def wait_for_file_to_exist(file_path, timeout):
     start_time = time.time()
-    file_wait_str = get_config_manager().get(WAIT_CGROUP_FILE_KEY, DEFAULT_WAIT_CGROUP_FILE_SEC)
-    file_wait_sec = int(file_wait_str)
 
     while not os.path.exists(file_path):
         log.debug("Waiting for file to exist: '{}'".format(file_path))
         time.sleep(0.1)
         elapsed_time = time.time() - start_time
 
-        if elapsed_time > file_wait_sec:
+        if elapsed_time > timeout:
             raise TimeoutError(
-                "Expected file '{}' was not created in '{}' seconds.".format(file_path, file_wait_sec))
+                "Expected file '{}' was not created in '{}' seconds.".format(file_path, timeout))
 
 
-def get_cpuset_path_from_list(cgroups_list):
+def _get_cgroup_path_from_list(cgroups_list, cgroup_name):
     for row in cgroups_list:
         r = row.split(":")
         name = r[1]
         path = r[2]
 
-        if name == "cpuset":
+        if name == cgroup_name:
             return path.strip()
 
     return None
 
 
-def get_cpuset_path_from_file(file_path):
-    log.info("Reading cpuset path from file: '{}'".format(file_path))
-    wait_for_file_to_exist(file_path)
+def get_cgroup_path_from_file(file_path, cgroup_name, timeout):
+    log.debug("Reading '{}' path from file: '{}'".format(cgroup_name, file_path))
+    wait_for_file_to_exist(file_path, timeout)
 
     with open(file_path, "r") as myfile:
         data = myfile.readlines()
-        return get_cpuset_path_from_list(data)
+        return _get_cgroup_path_from_list(data, cgroup_name)
 
 
-def get_cpuset_path(container_name):
-    info_file_path = "{}/{}/cgroup".format(ROOT_MESOS_INFO_PATH, container_name)
-    cpuset_file_path = get_cpuset_path_from_file(info_file_path)
-
-    return "{}/cpuset{}/cpuset.cpus".format(ROOT_CGROUP_PATH, cpuset_file_path)
+def __get_info_path(container_name):
+    return "{}/{}/cgroup".format(ROOT_MESOS_INFO_PATH, container_name)
 
 
-def set_cpuset(container_name, threads_str):
-    path = get_cpuset_path(container_name)
+def get_cpuset_path(container_name, timeout):
+    info_file_path = __get_info_path(container_name)
+    cgroup_path = get_cgroup_path_from_file(info_file_path, CPUSET, timeout)
+
+    return "{}/cpuset{}/cpuset.cpus".format(ROOT_CGROUP_PATH, cgroup_path)
+
+
+def get_quota_path(container_name, timeout):
+    info_file_path = __get_info_path(container_name)
+    cgroup_path = get_cgroup_path_from_file(info_file_path, CPU_CPUACCT, timeout)
+
+    return "{}/cpu,cpuacct{}/cpu.cfs_quota_us".format(ROOT_CGROUP_PATH, cgroup_path)
+
+
+def set_cpuset(container_name, threads_str, timeout):
+    path = get_cpuset_path(container_name, timeout)
+
+    orig_quota = get_quota(container_name, timeout)
+    log.info("Saved quota: '{}' for: '{}'".format(orig_quota, container_name))
+    set_quota(container_name, -1, timeout)
+
     log.info("Writing '{}' to path '{}'".format(threads_str, path))
-
     with open(path, 'w') as f:
         f.write(threads_str)
+
+    set_quota(container_name, orig_quota, timeout)
+
+
+def set_quota(container_name, value, timeout):
+    path = get_quota_path(container_name, timeout)
+
+    log.info("Writing '{}' to path '{}'".format(value, path))
+    with open(path, 'w') as f:
+        f.write(str(value))
+
+
+def get_quota(container_name, timeout):
+    path = get_quota_path(container_name, timeout)
+
+    log.info("Reading from path '{}'".format(path))
+    with open(path, 'r') as f:
+        return int(f.readline().strip())

--- a/titus_isolate/cgroup/utils.py
+++ b/titus_isolate/cgroup/utils.py
@@ -4,23 +4,51 @@ import time
 from titus_isolate import log
 
 ROOT_CGROUP_PATH = "/sys/fs/cgroup"
-ROOT_MESOS_INFO_PATH = "/var/lib/titus-inits"
+TITUS_INITS_PATH = "/var/lib/titus-inits"
+TITUS_ENVIRONMENTS_PATH = "/var/lib/titus-environments"
 
 CPUSET = "cpuset"
 CPU_CPUACCT = "cpu,cpuacct"
 
+JSON_WAIT_TIME = 1
 
-def wait_for_file_to_exist(file_path, timeout):
+
+def __get_info_path(container_name):
+    return "{}/{}/cgroup".format(TITUS_INITS_PATH, container_name)
+
+
+def __get_json_path(container_name):
+    return "{}/{}.json".format(TITUS_ENVIRONMENTS_PATH, container_name)
+
+
+def __noop():
+    pass
+
+
+def _wait_for_file_to_exist(path, timeout, check_func=__noop):
     start_time = time.time()
-
-    while not os.path.exists(file_path):
-        log.debug("Waiting for file to exist: '{}'".format(file_path))
+    while not os.path.exists(path):
+        log.debug("Waiting for file to exist: '{}'".format(path))
         time.sleep(0.1)
-        elapsed_time = time.time() - start_time
 
+        check_func()
+
+        elapsed_time = time.time() - start_time
         if elapsed_time > timeout:
             raise TimeoutError(
-                "Expected file '{}' was not created in '{}' seconds.".format(file_path, timeout))
+                "Expected file '{}' was not created in '{}' seconds.".format(path, timeout))
+
+
+def wait_for_files(container_name, timeout):
+    info_file_path = __get_info_path(container_name)
+    json_file_path = __get_json_path(container_name)
+
+    def __raise_if_json_file_gone():
+        if not os.path.exists(json_file_path):
+            raise RuntimeError("JSON file: '{}' disappeared, meaning the task exited.".format(json_file_path))
+
+    _wait_for_file_to_exist(json_file_path, JSON_WAIT_TIME)
+    _wait_for_file_to_exist(info_file_path, timeout, __raise_if_json_file_gone)
 
 
 def _get_cgroup_path_from_list(cgroups_list, cgroup_name):
@@ -35,30 +63,24 @@ def _get_cgroup_path_from_list(cgroups_list, cgroup_name):
     return None
 
 
-def get_cgroup_path_from_file(file_path, cgroup_name, timeout):
+def get_cgroup_path_from_file(file_path, cgroup_name):
     log.debug("Reading '{}' path from file: '{}'".format(cgroup_name, file_path))
-    wait_for_file_to_exist(file_path, timeout)
-
     with open(file_path, "r") as myfile:
         data = myfile.readlines()
         return _get_cgroup_path_from_list(data, cgroup_name)
 
 
-def __get_info_path(container_name):
-    return "{}/{}/cgroup".format(ROOT_MESOS_INFO_PATH, container_name)
-
-
 def get_cpuset_path(container_name, timeout):
-    info_file_path = __get_info_path(container_name)
-    cgroup_path = get_cgroup_path_from_file(info_file_path, CPUSET, timeout)
-
+    wait_for_files(container_name, timeout)
+    file_path = __get_info_path(container_name)
+    cgroup_path = get_cgroup_path_from_file(file_path, CPUSET)
     return "{}/cpuset{}/cpuset.cpus".format(ROOT_CGROUP_PATH, cgroup_path)
 
 
 def get_quota_path(container_name, timeout):
-    info_file_path = __get_info_path(container_name)
-    cgroup_path = get_cgroup_path_from_file(info_file_path, CPU_CPUACCT, timeout)
-
+    wait_for_files(container_name, timeout)
+    file_path = __get_info_path(container_name)
+    cgroup_path = get_cgroup_path_from_file(file_path, CPU_CPUACCT)
     return "{}/cpu,cpuacct{}/cpu.cfs_quota_us".format(ROOT_CGROUP_PATH, cgroup_path)
 
 


### PR DESCRIPTION
This also fixes a bug around waiting for the cgroup file to exist for tasks which have exited.  We only wait for the file on adding a workload, particularly in the burst case.  Otherwise the wait is `0`.

This change was verified on real workloads.