### PR TITLE
Detect allocator changes outside config manager

### DIFF
--- a/startup/titus-isolate
+++ b/startup/titus-isolate
@@ -8,6 +8,7 @@ import docker
 from titus_isolate import log
 from titus_isolate.api.status import app, set_wm, set_em
 from titus_isolate.cgroup.file_cgroup_manager import FileCgroupManager
+from titus_isolate.config.cpu_allocator_watcher import CpuAllocatorWatcher
 from titus_isolate.constants import FAILURE_EXIT_CODE
 from titus_isolate.docker.create_event_handler import CreateEventHandler
 from titus_isolate.docker.event_manager import EventManager
@@ -27,6 +28,11 @@ from titus_isolate.utils import start_periodic_scheduling, get_config_manager
 def main(admin_port):
     # Set the schedule library's logging level higher so it doesn't spam messages every time it schedules a task
     logging.getLogger('schedule').setLevel(logging.WARN)
+
+    exit_handler = RealExitHandler()
+
+    log.info("Starting watching for CPU allocator changes")
+    CpuAllocatorWatcher(get_config_manager(), exit_handler)
 
     log.info("Modeling the CPU...")
     cpu = get_cpu_from_env()
@@ -72,7 +78,7 @@ def main(admin_port):
     event_manager.join()
 
     log.error("The workload manager should never exit, yet here we are...")
-    RealExitHandler().exit(FAILURE_EXIT_CODE)
+    exit_handler.exit(FAILURE_EXIT_CODE)
 
 
 def __start_http_server(admin_port):

--- a/tests/config/test_config_manager.py
+++ b/tests/config/test_config_manager.py
@@ -2,11 +2,9 @@ import logging
 import unittest
 
 from tests.config.test_property_provider import TestPropertyProvider
-from tests.test_exit_handler import TestExitHandler
 from tests.utils import config_logs, wait_until
 from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.config.constants import ALLOCATOR_KEY, GREEDY, IP
-from titus_isolate.constants import ALLOCATOR_CONFIG_CHANGE_EXIT
 from titus_isolate.utils import start_periodic_scheduling
 
 config_logs(logging.DEBUG)
@@ -24,39 +22,33 @@ class TestConfigManager(unittest.TestCase):
 
     def test_none_to_something_update(self):
         property_provider = TestPropertyProvider({})
-        exit_handler = TestExitHandler()
-        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
         self.assertEqual(None, config_manager.get(ALLOCATOR_KEY))
 
         start_periodic_scheduling()
         property_provider.map[ALLOCATOR_KEY] = GREEDY
         wait_until(lambda: config_manager.get(ALLOCATOR_KEY) == GREEDY)
-        wait_until(lambda: ALLOCATOR_CONFIG_CHANGE_EXIT == exit_handler.last_code)
 
     def test_something_to_something_update(self):
         property_provider = TestPropertyProvider(
             {
                ALLOCATOR_KEY: IP
             })
-        exit_handler = TestExitHandler()
-        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
         self.assertEqual(IP, config_manager.get(ALLOCATOR_KEY))
 
         start_periodic_scheduling()
         property_provider.map[ALLOCATOR_KEY] = GREEDY
         wait_until(lambda: config_manager.get(ALLOCATOR_KEY) == GREEDY)
-        wait_until(lambda: ALLOCATOR_CONFIG_CHANGE_EXIT == exit_handler.last_code)
 
     def test_something_to_no_change_update(self):
         property_provider = TestPropertyProvider(
             {
                 ALLOCATOR_KEY: IP
             })
-        exit_handler = TestExitHandler()
-        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
         self.assertEqual(IP, config_manager.get(ALLOCATOR_KEY))
 
         original_update_count = config_manager.update_count
         start_periodic_scheduling()
         wait_until(lambda: config_manager.update_count > original_update_count)
-        self.assertTrue(exit_handler.last_code is None)

--- a/tests/config/test_cpu_allocator_watcher.py
+++ b/tests/config/test_cpu_allocator_watcher.py
@@ -1,0 +1,60 @@
+import logging
+import unittest
+
+from tests.config.test_property_provider import TestPropertyProvider
+from tests.test_exit_handler import TestExitHandler
+from tests.utils import config_logs
+from titus_isolate.config.config_manager import ConfigManager
+from titus_isolate.config.constants import ALLOCATOR_KEY, NOOP, IP, AB_TEST, CPU_ALLOCATOR_A, CPU_ALLOCATOR_B, \
+    EC2_INSTANCE_ID
+from titus_isolate.config.cpu_allocator_watcher import CpuAllocatorWatcher
+from titus_isolate.constants import ALLOCATOR_CONFIG_CHANGE_EXIT
+
+CONFIG_CHANGE_INTERVAL = 0.1
+
+config_logs(logging.DEBUG)
+
+
+class TestCpuAllocatorWatcher(unittest.TestCase):
+
+    def test_noop_to_ip_update(self):
+        property_provider = TestPropertyProvider(
+            {
+                ALLOCATOR_KEY: NOOP
+            })
+        exit_handler = TestExitHandler()
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
+
+        # No change yet
+        watcher.detect_allocator_change()
+        self.assertEqual(None, exit_handler.last_code)
+
+        # titus-isolate should exit when the allocator changes
+        property_provider.map[ALLOCATOR_KEY] = IP
+        watcher.detect_allocator_change()
+        self.assertEqual(ALLOCATOR_CONFIG_CHANGE_EXIT, exit_handler.last_code)
+
+    def test_ab_classification_swap(self):
+        even_instance_id = 'i-0cfefd19c9a8db976'
+        property_provider = TestPropertyProvider(
+            {
+                ALLOCATOR_KEY: AB_TEST,
+                CPU_ALLOCATOR_A: NOOP,
+                CPU_ALLOCATOR_B: IP,
+                EC2_INSTANCE_ID: even_instance_id
+            })
+        exit_handler = TestExitHandler()
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
+
+        # No change yet
+        watcher.detect_allocator_change()
+        self.assertEqual(None, exit_handler.last_code)
+
+        # Swap A and B to simulate instance classification change
+        # N.B. the ALLOCATOR_KEY and EC_INSTANCE_ID do NOT change
+        property_provider.map[CPU_ALLOCATOR_A] = IP
+        property_provider.map[CPU_ALLOCATOR_B] = NOOP
+        watcher.detect_allocator_change()
+        self.assertEqual(ALLOCATOR_CONFIG_CHANGE_EXIT, exit_handler.last_code)

--- a/tests/config/test_cpu_allocator_watcher.py
+++ b/tests/config/test_cpu_allocator_watcher.py
@@ -17,13 +17,34 @@ config_logs(logging.DEBUG)
 
 class TestCpuAllocatorWatcher(unittest.TestCase):
 
+    def test_none_to_something_update(self):
+        property_provider = TestPropertyProvider({})
+        exit_handler = TestExitHandler()
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
+        self.assertEqual(None, config_manager.get(ALLOCATOR_KEY))
+        watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
+
+        property_provider.map[ALLOCATOR_KEY] = IP
+        watcher.detect_allocator_change()
+        self.assertEqual(ALLOCATOR_CONFIG_CHANGE_EXIT, exit_handler.last_code)
+
+    def test_something_to_no_change_update(self):
+        property_provider = TestPropertyProvider({})
+        exit_handler = TestExitHandler()
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
+        self.assertEqual(None, config_manager.get(ALLOCATOR_KEY))
+        watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
+
+        watcher.detect_allocator_change()
+        self.assertEqual(None, exit_handler.last_code)
+
     def test_noop_to_ip_update(self):
         property_provider = TestPropertyProvider(
             {
                 ALLOCATOR_KEY: NOOP
             })
         exit_handler = TestExitHandler()
-        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
         watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
 
         # No change yet
@@ -45,7 +66,7 @@ class TestCpuAllocatorWatcher(unittest.TestCase):
                 EC2_INSTANCE_ID: even_instance_id
             })
         exit_handler = TestExitHandler()
-        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL, exit_handler)
+        config_manager = ConfigManager(property_provider, CONFIG_CHANGE_INTERVAL)
         watcher = CpuAllocatorWatcher(config_manager, exit_handler, CONFIG_CHANGE_INTERVAL)
 
         # No change yet

--- a/tests/isolate/test_utils.py
+++ b/tests/isolate/test_utils.py
@@ -1,13 +1,18 @@
+import logging
 import unittest
 
 from tests.config.test_property_provider import TestPropertyProvider
+from tests.utils import config_logs
+from titus_isolate import log
 from titus_isolate.allocate.greedy_cpu_allocator import GreedyCpuAllocator
 from titus_isolate.allocate.integer_program_cpu_allocator import IntegerProgramCpuAllocator
 from titus_isolate.allocate.noop_allocator import NoopCpuAllocator
 from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.config.constants import ALLOCATOR_KEY, NOOP, AB_TEST, GREEDY, CPU_ALLOCATOR_B, CPU_ALLOCATOR_A, IP, \
     EC2_INSTANCE_ID
-from titus_isolate.isolate.utils import get_allocator_class, get_ab_bucket
+from titus_isolate.isolate.utils import get_allocator_class, get_ab_bucket, _get_ab_bucket_int
+
+config_logs(logging.DEBUG)
 
 
 class TestUtils(unittest.TestCase):
@@ -32,7 +37,7 @@ class TestUtils(unittest.TestCase):
             })
         config_manager = ConfigManager(property_provider)
 
-        allocator_class = get_allocator_class(config_manager)
+        allocator_class = get_allocator_class(config_manager, 12)
         self.assertEqual(IntegerProgramCpuAllocator, allocator_class)
 
         odd_instance_id = 'i-0cfefd19c9a8db977'
@@ -45,7 +50,7 @@ class TestUtils(unittest.TestCase):
             })
         config_manager = ConfigManager(property_provider)
 
-        allocator_class = get_allocator_class(config_manager)
+        allocator_class = get_allocator_class(config_manager, 12)
         self.assertEqual(GreedyCpuAllocator, allocator_class)
 
     def test_ab_allocator_fallback(self):
@@ -72,7 +77,7 @@ class TestUtils(unittest.TestCase):
             })
         config_manager = ConfigManager(property_provider)
 
-        allocator_class = get_allocator_class(config_manager)
+        allocator_class = get_allocator_class(config_manager, 12)
         self.assertEqual(IntegerProgramCpuAllocator, allocator_class)
 
         odd_instance_id = 'i-0cfefd19c9a8db977'
@@ -85,7 +90,7 @@ class TestUtils(unittest.TestCase):
             })
         config_manager = ConfigManager(property_provider)
 
-        allocator_class = get_allocator_class(config_manager)
+        allocator_class = get_allocator_class(config_manager, 12)
         self.assertEqual(GreedyCpuAllocator, allocator_class)
 
     def test_undefined_instance_id(self):
@@ -110,7 +115,7 @@ class TestUtils(unittest.TestCase):
                 EC2_INSTANCE_ID: even_instance_id
             })
         config_manager = ConfigManager(property_provider)
-        self.assertEqual("A", get_ab_bucket(config_manager))
+        self.assertEqual("A", get_ab_bucket(config_manager, 12))
 
         odd_instance_id = 'i-0cfefd19c9a8db977'
         property_provider = TestPropertyProvider(
@@ -121,7 +126,7 @@ class TestUtils(unittest.TestCase):
                 EC2_INSTANCE_ID: odd_instance_id
             })
         config_manager = ConfigManager(property_provider)
-        self.assertEqual("B", get_ab_bucket(config_manager))
+        self.assertEqual("B", get_ab_bucket(config_manager, 12))
 
         letter_instance_id = 'i-0cfefd19c9a8db97x'
         property_provider = TestPropertyProvider(
@@ -132,7 +137,7 @@ class TestUtils(unittest.TestCase):
                 EC2_INSTANCE_ID: letter_instance_id
             })
         config_manager = ConfigManager(property_provider)
-        self.assertEqual("A", get_ab_bucket(config_manager))
+        self.assertEqual("A", get_ab_bucket(config_manager, 12))
 
     def test_get_ab_bucket_undefined(self):
         property_provider = TestPropertyProvider(
@@ -142,4 +147,71 @@ class TestUtils(unittest.TestCase):
                 CPU_ALLOCATOR_B: GREEDY
             })
         config_manager = ConfigManager(property_provider)
-        self.assertEqual("UNDEFINED", get_ab_bucket(config_manager))
+        self.assertEqual("UNDEFINED", get_ab_bucket(config_manager, 12))
+
+    def test_get_hourly_ab_bucket(self):
+        even_hour_to_bucket_map = {
+            0: 0,
+            1: 0,
+            2: 0,
+            3: 0,
+            4: 0,
+            5: 0,
+            6: 1,
+            7: 1,
+            8: 1,
+            9: 1,
+            10: 1,
+            11: 1,
+            12: 0,
+            13: 0,
+            14: 0,
+            15: 0,
+            16: 0,
+            17: 0,
+            18: 1,
+            19: 1,
+            20: 1,
+            21: 1,
+            22: 1,
+            23: 1
+        }
+
+        char = "4"
+        for hour in range(24):
+            bucket_int = _get_ab_bucket_int(char, hour)
+            log.info("{}: {}".format(hour, bucket_int))
+            self.assertEqual(even_hour_to_bucket_map[hour], bucket_int)
+
+        odd_hour_to_bucket_map = {
+            0: 1,
+            1: 1,
+            2: 1,
+            3: 1,
+            4: 1,
+            5: 1,
+            6: 0,
+            7: 0,
+            8: 0,
+            9: 0,
+            10: 0,
+            11: 0,
+            12: 1,
+            13: 1,
+            14: 1,
+            15: 1,
+            16: 1,
+            17: 1,
+            18: 0,
+            19: 0,
+            20: 0,
+            21: 0,
+            22: 0,
+            23: 0
+        }
+
+        char = "3"
+        for hour in range(24):
+            bucket_int = _get_ab_bucket_int(char, hour)
+            log.info("{}: {}".format(hour, bucket_int))
+            self.assertEqual(odd_hour_to_bucket_map[hour], bucket_int)

--- a/titus_isolate/config/config_manager.py
+++ b/titus_isolate/config/config_manager.py
@@ -5,7 +5,6 @@ import schedule
 from titus_isolate import log
 from titus_isolate.config.agent_property_provider import AgentPropertyProvider
 from titus_isolate.config.constants import PROPERTIES
-from titus_isolate.real_exit_handler import RealExitHandler
 
 PROPERTY_CHANGE_DETECTION_INTERVAL_SEC = 10
 
@@ -15,13 +14,11 @@ class ConfigManager:
     def __init__(
             self,
             property_provider=AgentPropertyProvider(),
-            property_change_interval=PROPERTY_CHANGE_DETECTION_INTERVAL_SEC,
-            exit_handler=RealExitHandler()):
+            property_change_interval=PROPERTY_CHANGE_DETECTION_INTERVAL_SEC):
 
         self.update_count = 0
 
         self.__property_provider = property_provider
-        self.__exit_handler = exit_handler
         self.__config_map = {}
         self.__lock = RLock()
 

--- a/titus_isolate/config/cpu_allocator_watcher.py
+++ b/titus_isolate/config/cpu_allocator_watcher.py
@@ -1,0 +1,34 @@
+import schedule
+
+from titus_isolate import log
+from titus_isolate.config.config_manager import PROPERTY_CHANGE_DETECTION_INTERVAL_SEC
+from titus_isolate.constants import ALLOCATOR_CONFIG_CHANGE_EXIT
+from titus_isolate.isolate.utils import get_allocator_class
+
+
+class CpuAllocatorWatcher:
+
+    def __init__(
+            self,
+            config_manager,
+            exit_handler,
+            detection_interval=PROPERTY_CHANGE_DETECTION_INTERVAL_SEC):
+
+        self.__config_manager = config_manager
+        self.__exit_handler = exit_handler
+
+        self.__last_allocator_name = get_allocator_class(self.__config_manager).__name__
+        schedule.every(detection_interval).seconds.do(self.detect_allocator_change)
+
+    def get_last_allocator_name(self):
+        return self.__last_allocator_name
+
+    def detect_allocator_change(self):
+        current_allocator_name = get_allocator_class(self.__config_manager).__name__
+
+        if current_allocator_name != self.__last_allocator_name:
+            log.info("The CPU allocator has changed from: '{}' to: '{}'".format(
+                self.__last_allocator_name, current_allocator_name))
+
+            self.__exit_handler.exit(ALLOCATOR_CONFIG_CHANGE_EXIT)
+

--- a/titus_isolate/isolate/utils.py
+++ b/titus_isolate/isolate/utils.py
@@ -1,10 +1,6 @@
 from titus_isolate import log
-from titus_isolate.allocate.greedy_cpu_allocator import GreedyCpuAllocator
-from titus_isolate.allocate.integer_program_cpu_allocator import IntegerProgramCpuAllocator
-from titus_isolate.allocate.noop_allocator import NoopCpuAllocator
-from titus_isolate.allocate.noop_reset_allocator import NoopResetCpuAllocator
-from titus_isolate.config.constants import ALLOCATOR_KEY, CPU_ALLOCATORS, IP, DEFAULT_ALLOCATOR, GREEDY, NOOP, \
-    CPU_ALLOCATOR_A, CPU_ALLOCATOR_B, AB_TEST, EC2_INSTANCE_ID, NOOP_RESET, CPU_ALLOCATOR_NAME_TO_CLASS_MAP
+from titus_isolate.config.constants import ALLOCATOR_KEY, CPU_ALLOCATORS, DEFAULT_ALLOCATOR, \
+    CPU_ALLOCATOR_A, CPU_ALLOCATOR_B, AB_TEST, EC2_INSTANCE_ID, CPU_ALLOCATOR_NAME_TO_CLASS_MAP
 from titus_isolate.docker.constants import BURST, STATIC
 
 BUCKETS = ["A", "B"]

--- a/titus_isolate/isolate/utils.py
+++ b/titus_isolate/isolate/utils.py
@@ -1,3 +1,5 @@
+import datetime
+
 from titus_isolate import log
 from titus_isolate.config.constants import ALLOCATOR_KEY, CPU_ALLOCATORS, DEFAULT_ALLOCATOR, \
     CPU_ALLOCATOR_A, CPU_ALLOCATOR_B, AB_TEST, EC2_INSTANCE_ID, CPU_ALLOCATOR_NAME_TO_CLASS_MAP
@@ -18,11 +20,11 @@ def get_workloads_by_type(workloads, workload_type):
     return [w for w in workloads if w.get_type() == workload_type]
 
 
-def get_allocator_class(config_manager):
+def get_allocator_class(config_manager, hour=datetime.datetime.utcnow().hour):
     alloc_str = config_manager.get(ALLOCATOR_KEY)
 
     if alloc_str == AB_TEST:
-        return __get_ab_allocator_class(config_manager)
+        return __get_ab_allocator_class(config_manager, hour)
     else:
         return __get_allocator_class(alloc_str)
 
@@ -35,14 +37,14 @@ def __get_allocator_class(allocator_str):
     return CPU_ALLOCATOR_NAME_TO_CLASS_MAP[allocator_str]
 
 
-def __get_ab_allocator_class(config_manager):
+def __get_ab_allocator_class(config_manager, hour):
     a_allocator_str = config_manager.get(CPU_ALLOCATOR_A)
     b_allocator_str = config_manager.get(CPU_ALLOCATOR_B)
 
     a_allocator_class = __get_allocator_class(a_allocator_str)
     b_allocator_class = __get_allocator_class(b_allocator_str)
 
-    bucket = get_ab_bucket(config_manager)
+    bucket = get_ab_bucket(config_manager, hour)
 
     if bucket not in BUCKETS:
         log.error("Unexpected A/B bucket specified: '{}', falling back to default: '{}'".format(bucket, DEFAULT_ALLOCATOR))
@@ -54,7 +56,7 @@ def __get_ab_allocator_class(config_manager):
     }[bucket]
 
 
-def get_ab_bucket(config_manager):
+def get_ab_bucket(config_manager, hour):
 
     instance_id = config_manager.get(EC2_INSTANCE_ID)
     if instance_id is None:
@@ -63,8 +65,16 @@ def get_ab_bucket(config_manager):
 
     # Take the last character of an instance id turn it into a number and determine whether it's odd or even.
     # An instance id looks like this: i-0cfefd19c9a8db976
-    bucket = ord(instance_id[-1]) % 2
+    char = instance_id[-1]
+    bucket = _get_ab_bucket_int(char, hour)
     if bucket == 0:
         return "A"
     else:
         return "B"
+
+
+def _get_ab_bucket_int(char, hour):
+    instance_int = ord(char)
+    hour = int(hour / 6)
+    int_bucket = (instance_int + (hour % 2)) % 2
+    return int_bucket


### PR DESCRIPTION
Also swap A/B bucket designation every 6 hours.

The algorithm for swapping matches what we've determined works on the SQL query end, so it may look slightly unusual.