### PR TITLE
Fix race around die events and adding running workloads

### DIFF
--- a/startup/titus-isolate
+++ b/startup/titus-isolate
@@ -68,6 +68,9 @@ def main(admin_port):
         except:
             log.exception("Failed to add currently running workload: '{}', maybe it exited.".format(workload.get_id()))
 
+    # Start processing events after adding running workloads to avoid processing a die event before we add a workload
+    event_manager.start_processing_events()
+
     # Starting the HTTP server blocks exit forever
     log.info("Starting HTTP server")
     __start_http_server(admin_port)

--- a/tests/api/test_status.py
+++ b/tests/api/test_status.py
@@ -61,6 +61,7 @@ class TestStatus(unittest.TestCase):
 
         event_manager = EventManager(MockEventProvider([]), [], 0.01)
         set_em(event_manager)
+        event_manager.start_processing_events()
 
         s = json.loads(get_wm_status())
         self.assertEqual(2, len(s))

--- a/tests/docker/test_events.py
+++ b/tests/docker/test_events.py
@@ -38,6 +38,7 @@ class TestEvents(unittest.TestCase):
             test_context.get_event_handlers(),
             DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: event_count == manager.get_processed_count())
         self.assertEqual(0, manager.get_queue_depth())
@@ -71,6 +72,7 @@ class TestEvents(unittest.TestCase):
             test_context.get_event_handlers(),
             DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: event_count == manager.get_processed_count())
         self.assertEqual(0, manager.get_queue_depth())
@@ -96,6 +98,7 @@ class TestEvents(unittest.TestCase):
             test_context.get_event_handlers(),
             DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: test_context.get_create_event_handler().get_ignored_event_count() == 1)
         self.assertEqual(0, manager.get_queue_depth())
@@ -125,6 +128,7 @@ class TestEvents(unittest.TestCase):
             test_context.get_event_handlers(),
             DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: test_context.get_create_event_handler().get_ignored_event_count() == 1)
         self.assertEqual(0, manager.get_queue_depth())
@@ -153,6 +157,7 @@ class TestEvents(unittest.TestCase):
         event_iterable = MockEventProvider([unknown_event])
         manager = EventManager(event_iterable, event_handlers, DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: test_context.get_create_event_handler().get_ignored_event_count() == 1)
         self.assertEqual(0, manager.get_queue_depth())
@@ -180,6 +185,7 @@ class TestEvents(unittest.TestCase):
             test_context.get_event_handlers(),
             DEFAULT_TEST_EVENT_TIMEOUT_SECS)
         manager.set_registry(registry)
+        manager.start_processing_events()
 
         wait_until(lambda: manager.get_error_count() == 1)
         wait_until(lambda: manager.get_processed_count() == 2)


### PR DESCRIPTION
See these logs about workload `09f02073-039d-4b1c-85de-6c82b572a3d5`:
```
2019-01-29 18:26:01,397,397 INFO [event_handler.py:17] 'FreeEventHandler' handling event.  msg: 'removing workload: '09f02073-039d-4b1c-85de-6c82b572a3d5'', event: '{'status': 'die', 'timeNano': 1548786361397469083, 'scope': 'local', 'from': 'tita
2019-01-29 18:26:01,398,398 INFO [workload_manager.py:65] Acquired lock for func: __remove_workload on workload: 09f02073-039d-4b1c-85de-6c82b572a3d5
2019-01-29 18:26:01,398,398 INFO [workload_manager.py:118] Removing workload: 09f02073-039d-4b1c-85de-6c82b572a3d5
2019-01-29 18:26:01,398,398 ERROR [workload_manager.py:74] Failed to execute func: __remove_workload on workload: 09f02073-039d-4b1c-85de-6c82b572a3d5
Traceback (most recent call last):
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 67, in __update_workload
    func(arg)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 120, in __remove_workload
    raise ValueError("Attempted to remove unknown workload: '{}'".format(workload_id))
ValueError: Attempted to remove unknown workload: '09f02073-039d-4b1c-85de-6c82b572a3d5'
2019-01-29 18:26:01,399,399 INFO [event_handler.py:20] 'FreeEventHandler' handled event.  msg: 'removed workload: '09f02073-039d-4b1c-85de-6c82b572a3d5'', event: '{'status': 'die', 'timeNano': 1548786361397469083, 'scope': 'local', 'from': 'titan-
2019-01-29 18:26:01,514,514 INFO [utils.py:28] Found running workload: 'ebcf018b-edcf-480f-aa85-07a1046bc7c4'
2019-01-29 18:26:01,515,515 INFO [utils.py:28] Found running workload: 'fc8fdc40-5d9c-4992-be65-5df921511046'
2019-01-29 18:26:01,515,515 INFO [utils.py:28] Found running workload: 'f70b7ed1-e637-4385-873d-c3884c66536f'
2019-01-29 18:26:01,515,515 INFO [utils.py:28] Found running workload: '09f02073-039d-4b1c-85de-6c82b572a3d5'
```
You'll note that Docker sent us a `die` event which we processed.  We didn't know about that workload because we were just starting up.  So it was dropped on the floor, under the assumption that we wouldn't re-add it later because it's dead, so no problem.  However in the last line of the logs we see that when we asked Docker for the currently running containers we got back that container so it was re-added.  So he have a dangling container.

The fix is:
1. Get the event iterable from Docker first, but process nothing.
1. Add all the current workloads as reported by Docker
1. Process the events.

Now events will be processed in the appropriate order.