### PR TITLE
Complete transformation of CpuAllocators to stateless objects

### DIFF
--- a/tests/allocate/crashing_allocators.py
+++ b/tests/allocate/crashing_allocators.py
@@ -3,17 +3,29 @@ from titus_isolate.allocate.cpu_allocator import CpuAllocator
 
 class CrashingAllocator(CpuAllocator):
 
-    def assign_threads(self, cpu, workload):
+    def assign_threads(self, cpu, workload_id, workloads):
         raise Exception("")
 
-    def free_threads(self, cpu, workload_id):
+    def free_threads(self, cpu, workload_id, workloads):
         raise Exception("")
+
+    def set_registry(self, registry):
+        pass
+
+    def report_metrics(self, tags):
+        pass
 
 
 class CrashingAssignAllocator(CpuAllocator):
 
-    def assign_threads(self, cpu, workload):
+    def assign_threads(self, cpu, workload_id, workloads):
         raise Exception("")
 
-    def free_threads(self, cpu, workload_id):
+    def free_threads(self, cpu, workload_id, workloads):
+        pass
+
+    def set_registry(self, registry):
+        pass
+
+    def report_metrics(self, tags):
         pass

--- a/tests/allocate/test_fallback_cpu_allocator.py
+++ b/tests/allocate/test_fallback_cpu_allocator.py
@@ -20,13 +20,25 @@ class TestFallbackCpuAllocator(unittest.TestCase):
         cpu = get_cpu(package_count=2, cores_per_package=2, threads_per_core=2)
 
         allocator = FallbackCpuAllocator(CrashingAllocator(), GreedyCpuAllocator())
+        workloads = {}
 
-        cpu = allocator.assign_threads(cpu, w_a)
-        cpu = allocator.assign_threads(cpu, w_b)
-        cpu = allocator.free_threads(cpu, "a")
-        cpu = allocator.assign_threads(cpu, w_c)
-        cpu = allocator.free_threads(cpu, "b")
-        cpu = allocator.assign_threads(cpu, w_d)
+        workloads[w_a.get_id()] = w_a
+        cpu = allocator.assign_threads(cpu, w_a.get_id(), workloads)
+
+        workloads[w_b.get_id()] = w_b
+        cpu = allocator.assign_threads(cpu, w_b.get_id(), workloads)
+
+        cpu = allocator.free_threads(cpu, "a", workloads)
+        workloads.pop("a")
+
+        workloads[w_c.get_id()] = w_c
+        cpu = allocator.assign_threads(cpu, w_c.get_id(), workloads)
+
+        cpu = allocator.free_threads(cpu, "b", workloads)
+        workloads.pop("b")
+
+        workloads[w_d.get_id()] = w_d
+        cpu = allocator.assign_threads(cpu, w_d.get_id(), workloads)
 
         self.assertEqual(3, len(cpu.get_claimed_threads()))
         self.assertEqual(6, allocator.get_fallback_allocator_calls_count())

--- a/tests/isolate/test_balance.py
+++ b/tests/isolate/test_balance.py
@@ -21,10 +21,10 @@ class TestBalance(unittest.TestCase):
         new_cpu = get_cpu()
 
         allocator0 = GreedyCpuAllocator()
-        cur_cpu = allocator0.assign_threads(cur_cpu, w0)
+        cur_cpu = allocator0.assign_threads(cur_cpu, w0.get_id(), {w0.get_id(): w0})
 
         allocator1 = GreedyCpuAllocator()
-        new_cpu = allocator1.assign_threads(new_cpu, w0)
+        new_cpu = allocator1.assign_threads(new_cpu, w0.get_id(), {w0.get_id(): w0})
 
         self.assertFalse(has_better_isolation(cur_cpu, new_cpu))
 

--- a/tests/isolate/test_utils.py
+++ b/tests/isolate/test_utils.py
@@ -10,7 +10,9 @@ from titus_isolate.allocate.noop_allocator import NoopCpuAllocator
 from titus_isolate.config.config_manager import ConfigManager
 from titus_isolate.config.constants import ALLOCATOR_KEY, NOOP, AB_TEST, GREEDY, CPU_ALLOCATOR_B, CPU_ALLOCATOR_A, IP, \
     EC2_INSTANCE_ID
-from titus_isolate.isolate.utils import get_allocator, get_ab_bucket, _get_ab_bucket_int
+from titus_isolate.docker.constants import STATIC
+from titus_isolate.isolate.utils import get_allocator, get_ab_bucket, _get_ab_bucket_int, get_sorted_workloads
+from titus_isolate.model.workload import Workload
 
 config_logs(logging.DEBUG)
 
@@ -215,3 +217,15 @@ class TestUtils(unittest.TestCase):
             bucket_int = _get_ab_bucket_int(char, hour)
             log.info("{}: {}".format(hour, bucket_int))
             self.assertEqual(odd_hour_to_bucket_map[hour], bucket_int)
+
+    def test_get_sorted_workloads(self):
+        w_a = Workload('a', 1, STATIC)
+        w_b = Workload('b', 1, STATIC)
+        w_c = Workload('c', 1, STATIC)
+        expected_ids = ['a', 'b', 'c']
+
+        scrambled_workloads = [w_b, w_a, w_c]
+        sorted_workloads = get_sorted_workloads(scrambled_workloads)
+        actual_ids = [w.get_id() for w in sorted_workloads]
+
+        self.assertEqual(expected_ids, actual_ids)

--- a/tests/isolate/test_workload_manager.py
+++ b/tests/isolate/test_workload_manager.py
@@ -220,8 +220,8 @@ class TestWorkloadManager(unittest.TestCase):
         self.assertTrue(gauge_value_equals(registry, EMPTY_CORES_KEY, 6))
 
     def test_edge_case_ip_allocator_metrics(self):
-        # this is a specific scenario causing troubles to the solver.
-        # we should hit the time-bound limit and report it.
+        # This is a specific scenario causing troubles to the solver.
+        # We should hit the time-bound limit and report it.
 
         registry = Registry()
 

--- a/titus_isolate/allocate/cpu_allocator.py
+++ b/titus_isolate/allocate/cpu_allocator.py
@@ -1,16 +1,33 @@
 import abc
 
 from titus_isolate.metrics.metrics_reporter import MetricsReporter
+from titus_isolate.model.processor.cpu import Cpu
 
 
 class CpuAllocator(abc.ABC, MetricsReporter):
 
     @abc.abstractmethod
-    def assign_threads(self, cpu, workload):
+    def assign_threads(self, cpu: Cpu, workload_id: str, workloads: dict) -> Cpu:
+        """
+        Implementations of this method should claim threads for a workload on a given CPU.
+
+        :param cpu: An object indicating the state of the CPU before workload assignment
+        :param workload_id: The id of the workload being assigned.
+        :param workloads: A map of all relevant workloads including the workload to be assigned.
+        The keys are workload ids, the objects are Workload objects.
+        """
         pass
 
     @abc.abstractmethod
-    def free_threads(self, cpu, workload_id):
+    def free_threads(self, cpu: Cpu, workload_id: str, workloads: dict) -> Cpu:
+        """
+        Implementations of this method should free threads claimed by a workload on a given CPU.
+
+        :param cpu: An object indicating the state of the CPU before freeing threads
+        :param workload_id: The id of the workload being removed.
+        :param workloads: A map of all relevant workloads including the workload to be removed.
+        The keys are workload ids, the values are Workload objects.
+        """
         pass
 
     def str(self):

--- a/titus_isolate/allocate/fall_back_cpu_allocator.py
+++ b/titus_isolate/allocate/fall_back_cpu_allocator.py
@@ -17,40 +17,35 @@ class FallbackCpuAllocator(CpuAllocator):
         self.__primary_allocator = primary_cpu_allocator
         self.__secondary_allocator = secondary_cpu_allocator
 
-        self.__primary_allocator_calls_count = 0
         self.__secondary_allocator_calls_count = 0
 
         log.info("Created FallbackCpuAllocator with primary cpu allocator: '{}' and secondary cpu allocator: '{}'".format(
             self.__primary_allocator.__class__.__name__,
             self.__secondary_allocator.__class__.__name__))
 
-    def assign_threads(self, cpu, workload):
+    def assign_threads(self, cpu, workload_id, workloads):
         try:
-            cpu = self.__primary_allocator.assign_threads(cpu, workload)
-            self.__primary_allocator_calls_count += 1
-            return cpu
+            return self.__primary_allocator.assign_threads(cpu, workload_id, workloads)
         except:
             log.exception(
                 "Failed to assign threads to workload: '{}' with primary allocator: '{}', falling back to: '{}'".format(
-                    workload.get_id(),
+                    workload_id,
                     self.__primary_allocator.__class__.__name__,
                     self.__secondary_allocator.__class__.__name__))
-            cpu = self.__secondary_allocator.assign_threads(cpu, workload)
+            cpu = self.__secondary_allocator.assign_threads(cpu, workload_id, workloads)
             self.__secondary_allocator_calls_count += 1
             return cpu
 
-    def free_threads(self, cpu, workload_id):
+    def free_threads(self, cpu, workload_id, workloads):
         try:
-            cpu = self.__primary_allocator.free_threads(cpu, workload_id)
-            self.__primary_allocator_calls_count += 1
-            return cpu
+            return self.__primary_allocator.free_threads(cpu, workload_id, workloads)
         except:
             log.exception(
                 "Failed to free threads for workload: '{}' with primary allocator: '{}', falling back to: '{}'".format(
                     workload_id,
                     self.__primary_allocator.__class__.__name__,
                     self.__secondary_allocator.__class__.__name__))
-            cpu = self.__secondary_allocator.free_threads(cpu, workload_id)
+            cpu = self.__secondary_allocator.free_threads(cpu, workload_id, workloads)
             self.__secondary_allocator_calls_count += 1
             return cpu
 

--- a/titus_isolate/allocate/greedy_cpu_allocator.py
+++ b/titus_isolate/allocate/greedy_cpu_allocator.py
@@ -6,8 +6,8 @@ from titus_isolate.model.workload import Workload
 
 class GreedyCpuAllocator(CpuAllocator):
 
-    def assign_threads(self, cpu, workload):
-        self.__assign_threads(cpu, workload)
+    def assign_threads(self, cpu, workload_id, workloads):
+        self.__assign_threads(cpu, workloads[workload_id])
         return cpu
 
     def __assign_threads(self, cpu, workload):
@@ -34,7 +34,7 @@ class GreedyCpuAllocator(CpuAllocator):
             cpu,
             Workload(workload.get_id(), thread_count, workload.get_type()))
 
-    def free_threads(self, cpu, workload_id):
+    def free_threads(self, cpu, workload_id, workloads):
         for t in cpu.get_threads():
             if t.get_workload_id() == workload_id:
                 t.free()

--- a/titus_isolate/isolate/utils.py
+++ b/titus_isolate/isolate/utils.py
@@ -32,6 +32,10 @@ def get_workloads_by_type(workloads, workload_type):
     return [w for w in workloads if w.get_type() == workload_type]
 
 
+def get_sorted_workloads(workloads):
+    return sorted(workloads, key=lambda w: w.get_creation_time())
+
+
 def get_allocator(config_manager, hour=None):
     if hour is None:
         hour = datetime.datetime.utcnow().hour

--- a/titus_isolate/isolate/workload_manager.py
+++ b/titus_isolate/isolate/workload_manager.py
@@ -73,7 +73,7 @@ class WorkloadManager(MetricsReporter):
         new_cpu = self.__cpu
         if workload.get_type() == STATIC:
             current_cpu = copy.deepcopy(self.get_cpu())
-            new_cpu = self.__cpu_allocator.assign_threads(self.__cpu, workload)
+            new_cpu = self.__cpu_allocator.assign_threads(copy.deepcopy(self.__cpu), workload.get_id(), self.__workloads)
             updates = get_updates(current_cpu, new_cpu)
             log.info("Found footprint updates: '{}'".format(updates))
             self.__update_static_cpusets(updates)
@@ -92,7 +92,7 @@ class WorkloadManager(MetricsReporter):
         if workload_id not in self.__workloads:
             raise ValueError("Attempted to remove unknown workload: '{}'".format(workload_id))
 
-        self.__cpu = self.__cpu_allocator.free_threads(self.__cpu, workload_id)
+        self.__cpu = self.__cpu_allocator.free_threads(copy.deepcopy(self.__cpu), workload_id, self.__workloads)
         self.__workloads.pop(workload_id)
 
         self.__update_burst_cpusets()
@@ -154,7 +154,7 @@ class WorkloadManager(MetricsReporter):
         return self.__allocator_call_duration_sum_secs
 
     def get_allocator_name(self):
-        return str(self.__cpu_allocator)
+        return self.__cpu_allocator.__class__.__name__
 
     def set_registry(self, registry):
         self.__reg = registry

--- a/titus_isolate/metrics/metrics_manager.py
+++ b/titus_isolate/metrics/metrics_manager.py
@@ -38,7 +38,7 @@ class MetricsManager:
         if ec2_instance_id in os.environ:
             tags["node"] = os.environ[ec2_instance_id]
 
-        allocator_name = get_allocator(get_config_manager()).__name__
+        allocator_name = get_allocator(get_config_manager()).__class__.__name__
         tags["cpu_allocator"] = allocator_name
 
         return tags

--- a/titus_isolate/model/workload.py
+++ b/titus_isolate/model/workload.py
@@ -1,8 +1,11 @@
+import datetime
+
 from titus_isolate.docker.constants import WORKLOAD_TYPES, BURST
 
 
 class Workload:
     def __init__(self, identifier, thread_count, workload_type):
+        self.__creation_time = datetime.datetime.utcnow()
         self.__identifier = identifier
         self.__thread_count = int(thread_count)
         self.__type = workload_type.lower()
@@ -26,12 +29,17 @@ class Workload:
     def get_type(self):
         return self.__type
 
+    def get_creation_time(self):
+        return self.__creation_time
+
     def to_dict(self):
         return {
+            "creation_time": str(self.__creation_time),
             "id": self.get_id(),
             "type": self.get_type(),
             "thread_count": self.get_thread_count()
         }
 
     def __str__(self):
-        return "id: {}, type: {}, thread_count: {}".format(self.get_id(), self.get_type(), self.get_thread_count())
+        return "id: {}, type: {}, thread_count: {}, creation_time: {}".format(
+            self.get_id(), self.get_type(), self.get_thread_count(), self.get_creation_time())


### PR DESCRIPTION
1. Change the CpuAllocator interface to be consistent across `assign` and `free` calls.  Always pass the workload_id under consideration and a map of all workloads.
1. Add a timestamp to `Workload` objects so they an be ordered by creation time.