### PR TITLE
Add before and after snapshots of the cpu on cpuset updates

### DIFF
--- a/titus_isolate/isolate/workload_manager.py
+++ b/titus_isolate/isolate/workload_manager.py
@@ -161,12 +161,13 @@ class WorkloadManager(MetricsReporter):
         return new_cpu
 
     def __update_state(self, new_cpu, new_workloads):
-        updated = self.__apply_cpuset_updates(copy.deepcopy(self.get_cpu()), new_cpu)
+        old_cpu = copy.deepcopy(self.get_cpu())
+        updated = self.__apply_cpuset_updates(old_cpu, new_cpu)
         self.__cpu = new_cpu
         self.__workloads = new_workloads
 
         if updated:
-            self.__report_cpu_state(self.__cpu)
+            self.__report_cpu_state(old_cpu, new_cpu)
 
     def __apply_cpuset_updates(self, old_cpu, new_cpu):
         updates = get_updates(old_cpu, new_cpu)
@@ -234,9 +235,9 @@ class WorkloadManager(MetricsReporter):
         return len([t for t in core.get_threads() if t.is_claimed()])
 
     @staticmethod
-    def __report_cpu_state(cpu):
-        log.info("Applied updates resulting in cpu: {}".format(cpu))
-        Thread(target=report_cpu, args=[cpu]).start()
+    def __report_cpu_state(old_cpu, new_cpu):
+        log.info("old cpu: {}\nnew cpu: {}".format(old_cpu, new_cpu))
+        Thread(target=report_cpu, args=[new_cpu]).start()
 
     def report_metrics(self, tags):
         self.__reg.gauge(RUNNING, tags).set(1)


### PR DESCRIPTION
```
01-03-2019:17:20:40,121 INFO [update.py:11] workload: 'burst0' updated threads from: '[]' to: '[1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]'
01-03-2019:17:20:40,121 INFO [workload_manager.py:175] updating workload: 'burst0' to '[1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]'
01-03-2019:17:20:40,121 DEBUG [mock_cgroup_manager.py:12] Updating container: 'burst0' to cpuset: '[1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15]'
01-03-2019:17:20:40,122 INFO [workload_manager.py:239] old cpu: 2 packages, 8 cores per package, 2 threads per core
2 threads claimed
| a |   |   |   |   a: ['static0']
| a |   |   |   |
| ------------- |
|   |   |   |   |
|   |   |   |   |

new cpu: 2 packages, 8 cores per package, 2 threads per core
16 threads claimed
| a | b | b | b |   a: ['static0']
| a | b | b | b |   b: ['burst0']
| ------------- |
| b | b | b | b |
| b | b | b | b |
```