### PR TITLE
Remove app name as required label

### DIFF
--- a/titus_isolate/event/constants.py
+++ b/titus_isolate/event/constants.py
@@ -29,7 +29,6 @@ ENTRYPOINT_LABEL_KEY = "com.netflix.titus.entrypoint"
 IMAGE_LABEL_KEY = "image"
 
 REQUIRED_LABELS = [
-    APP_NAME_LABEL_KEY,
     CPU_LABEL_KEY,
     MEM_LABEL_KEY,
     DISK_LABEL_KEY,


### PR DESCRIPTION
App name cannot be a required label until all tasks have restarted.  This is no longer guaranteed since we have started using mutable deployments.