### PR TITLE
Fix indexing outside of timestamp range

### DIFF
--- a/titus_isolate/monitor/workload_perf_mon.py
+++ b/titus_isolate/monitor/workload_perf_mon.py
@@ -71,6 +71,12 @@ class WorkloadPerformanceMonitor:
             if slice_ts_min == slice_ts_max:
                 continue
 
+            if slice_ts_min < 0 or slice_ts_min >= len(timestamps):
+                continue
+
+            if slice_ts_max < 0 or slice_ts_max >= len(timestamps):
+                continue
+
             if timestamps[slice_ts_max] < ts_min - bucket_size_secs:
                 continue
             # this should be matching Atlas:


### PR DESCRIPTION
Sometimes we see this stack trace:
```
Traceback (most recent call last):
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 81, in __update_workload
    func(arg)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 99, in __add_workload
    cpu_usage = self.__wmm.get_cpu_usage(seconds=3600, agg_granularity_secs=60)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/monitor/workload_monitor_manager.py", line 30, in get_cpu_usage
    cpu_usage[workload_id] = monitor.get_normalized_cpu_usage_last_seconds(seconds, agg_granularity_secs)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/monitor/workload_perf_mon.py", line 34, in get_normalized_cpu_usage_last_seconds
    return WorkloadPerformanceMonitor.normalize_data(*self.get_buffers(), num_buckets, agg_granularity_secs)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/monitor/workload_perf_mon.py", line 77, in normalize_data
    time_diff_ns = (timestamps[slice_ts_max] - timestamps[slice_ts_min]) * 1000000000
IndexError: list index out of range
```
This change does sanity checking for the indices.
