### PR TITLE
Fix locking around performance monitoring

### DIFF
--- a/titus_isolate/metrics/event_log.py
+++ b/titus_isolate/metrics/event_log.py
@@ -46,7 +46,7 @@ def get_cpu_event(cpu: Cpu, usage: dict, workloads: dict):
             "instance": os.environ['EC2_INSTANCE_ID'],
             "cpu": cpu.to_dict(),
             "cpu_usage": usage,
-            "workloads:": workloads
+            "workloads": workloads
         }
     }
 
@@ -65,7 +65,7 @@ def report_cpu(cpu: Cpu, workloads):
 
     serializable_usage = {}
     for w_id, usage in usage.items():
-        serializable_usage[w_id] = [str(u) for u in usage]
+        serializable_usage[w_id] = [float(u) for u in usage]
 
     serializable_workloads = {}
     for w in workloads:

--- a/titus_isolate/monitor/workload_monitor_manager.py
+++ b/titus_isolate/monitor/workload_monitor_manager.py
@@ -25,9 +25,10 @@ class WorkloadMonitorManager(CpuUsageProvider, MetricsReporter):
         schedule.every(sample_interval).seconds.do(self.__sample)
 
     def get_cpu_usage(self, seconds: int, agg_granularity_secs: int) -> dict:
-        cpu_usage = {}
-        for workload_id, monitor in self.get_monitors().items():
-            cpu_usage[workload_id] = monitor.get_normalized_cpu_usage_last_seconds(seconds, agg_granularity_secs)
+        with self.__lock:
+            cpu_usage = {}
+            for workload_id, monitor in self.get_monitors().items():
+                cpu_usage[workload_id] = monitor.get_normalized_cpu_usage_last_seconds(seconds, agg_granularity_secs)
 
         return cpu_usage
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 81, in __update_workload
    func(arg)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/isolate/workload_manager.py", line 113, in __remove_workload
    cpu_usage = self.__wmm.get_cpu_usage(seconds=3600, agg_granularity_secs=60)
  File "/usr/share/python/titus-isolate/lib/python3.5/site-packages/titus_isolate/monitor/workload_monitor_manager.py", line 29, in get_cpu_usage
    for workload_id, monitor in self.get_monitors().items():
RuntimeError: dictionary changed size during iteration
```