### PR TITLE
Fix duplicate entries in the isolated_workloads list

### DIFF
--- a/startup/titus-isolate
+++ b/startup/titus-isolate
@@ -59,11 +59,11 @@ def main(admin_port):
 
     # Setup the workload manager
     log.info("Setting up the workload manager...")
-    cgroup_manager = FileCgroupManager()
     cpu_allocator = get_fallback_allocator(get_config_manager())
     log.info("Created Fallback CPU allocator with primary: '{}' and secondary: '{}".format(
         cpu_allocator.get_primary_allocator().__class__.__name__,
         cpu_allocator.get_secondary_allocator().__class__.__name__))
+    cgroup_manager = FileCgroupManager()
     workload_manager = WorkloadManager(
         cpu=cpu,
         cgroup_manager=cgroup_manager,

--- a/titus_isolate/api/status.py
+++ b/titus_isolate/api/status.py
@@ -3,6 +3,7 @@ import time
 
 from flask import Flask
 
+from titus_isolate import log
 from titus_isolate.config.constants import TITUS_ISOLATE_BLOCK_SEC, DEFAULT_TITUS_ISOLATE_BLOCK_SEC
 from titus_isolate.isolate.detect import get_cross_package_violations, get_shared_core_violations
 from titus_isolate.utils import get_config_manager, get_workload_manager, get_event_manager, \
@@ -22,6 +23,7 @@ def isolate_workload(workload_id, timeout=None):
             return json.dumps({'workload_id': workload_id}), 200, {'ContentType': 'application/json'}
         time.sleep(0.1)
 
+    log.error("Failed to isolate workload: '{}'".format(workload_id))
     return json.dumps({'unknown_workload_id': workload_id}), 404, {'ContentType': 'application/json'}
 
 
@@ -33,7 +35,7 @@ def get_workloads():
 
 @app.route('/isolated_workload_ids')
 def get_isolated_workload_ids():
-    return json.dumps(get_workload_manager().get_isolated_workload_ids())
+    return json.dumps(list(get_workload_manager().get_isolated_workload_ids()))
 
 
 @app.route('/cpu')


### PR DESCRIPTION
Actual writes to the filesystem are asynchronous so add/remove
operations have no ordering guarantees.  This causes occasional leaking
of workload IDs.  Here we lazily remove any entries which are unknown to
the workload manager.  It is impossible for a workload to be isolated if
the workload manager isn't tracking it.