### PR TITLE
Claim threads for the burst pool which may be safely claimed

### DIFF
--- a/tests/allocate/test_utils.py
+++ b/tests/allocate/test_utils.py
@@ -1,0 +1,82 @@
+import unittest
+
+from tests.utils import get_test_workload
+from titus_isolate.allocate.utils import is_burst_core
+from titus_isolate.event.constants import BURST, STATIC
+from titus_isolate.model.processor.core import Core
+from titus_isolate.model.processor.thread import Thread
+
+
+class TestUtils(unittest.TestCase):
+
+    def test_empty_core_is_burst_core(self):
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+        self.assertTrue(is_burst_core(core, {}))
+
+    def test_single_burst_workload_is_burst_core(self):
+        w = get_test_workload("a", 2, BURST)
+        w_map = {w.get_id(): w}
+
+        # First thread is BURST, other is unclaimed
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t0.claim(w.get_id())
+        self.assertTrue(is_burst_core(core, w_map))
+
+        # Second thread is BURST, other is unclaimed
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t1.claim(w.get_id())
+        self.assertTrue(is_burst_core(core, w_map))
+
+    def test_single_static_workload_is_not_burst_core(self):
+        w = get_test_workload("a", 2, STATIC)
+        w_map = {w.get_id(): w}
+
+        # First thread is STATIC, other is unclaimed
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t0.claim(w.get_id())
+        self.assertFalse(is_burst_core(core, w_map))
+
+        # Second thread is STATIC, other is unclaimed
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t1.claim(w.get_id())
+        self.assertFalse(is_burst_core(core, w_map))
+
+    def test_mixed_workloads_is_not_burst_core(self):
+        w_static = get_test_workload("a", 2, STATIC)
+        w_burst = get_test_workload("b", 2, BURST)
+        w_map = {
+            w_static.get_id(): w_static,
+            w_burst.get_id(): w_burst
+        }
+
+        # First thread is STATIC, other is BURST
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t0.claim(w_static.get_id())
+        t1.claim(w_burst.get_id())
+        self.assertFalse(is_burst_core(core, w_map))
+
+        # Second thread is STATIC, other is BURST
+        t0 = Thread(0)
+        t1 = Thread(32)
+        core = Core(0, [t0, t1])
+
+        t0.claim(w_burst.get_id())
+        t1.claim(w_static.get_id())
+        self.assertFalse(is_burst_core(core, w_map))

--- a/titus_isolate/allocate/utils.py
+++ b/titus_isolate/allocate/utils.py
@@ -6,12 +6,27 @@ from titus_isolate import log
 from titus_isolate.config.constants import MODEL_BUCKET_FORMAT_STR, MODEL_BUCKET_PREFIX, \
     DEFAULT_MODEL_BUCKET_PREFIX, MODEL_BUCKET_LEAF, DEFAULT_MODEL_BUCKET_LEAF, MODEL_PREFIX_FORMAT_STR
 from titus_isolate.config.utils import get_required_property
+from titus_isolate.event.constants import BURST
 from titus_isolate.model.processor.core import Core
 from titus_isolate.model.processor.cpu import Cpu
 from titus_isolate.model.processor.package import Package
 from titus_isolate.model.processor.thread import Thread
+from titus_isolate.model.utils import is_thread_occupied
 from titus_isolate.model.workload import Workload
 from titus_isolate.utils import get_config_manager
+
+
+def get_burst_cores(cpu: Cpu, workload_map) -> list:
+    return [c for c in cpu.get_cores() if is_burst_core(c, workload_map)]
+
+
+def is_burst_core(core: Core, workload_map) -> bool:
+    is_burst = True
+    for t in core.get_threads():
+        if t.is_claimed() and not is_thread_occupied(t, workload_map, BURST):
+            is_burst = False
+
+    return is_burst
 
 
 def get_threads_body(cpu: Cpu, workload_id: str, workloads: dict, cpu_usage: dict) -> dict:

--- a/titus_isolate/isolate/metrics_utils.py
+++ b/titus_isolate/isolate/metrics_utils.py
@@ -2,7 +2,7 @@ from titus_isolate.event.constants import BURST, STATIC
 from titus_isolate.model.processor.core import Core
 from titus_isolate.model.processor.cpu import Cpu
 from titus_isolate.model.processor.thread import Thread
-from titus_isolate.model.utils import get_burst_workloads
+from titus_isolate.model.utils import get_burst_workloads, is_thread_occupied
 
 
 def get_allocated_size(cpu: Cpu) -> int:
@@ -32,7 +32,7 @@ def get_static_allocated_size(cpu: Cpu, workload_map: dict) -> int:
 def _get_allocated_size(cpu: Cpu, workload_map: dict, w_type: str) -> int:
     allocation_size = 0
     for t in cpu.get_threads():
-        if _is_thread_occupied(t, workload_map, w_type):
+        if is_thread_occupied(t, workload_map, w_type):
             allocation_size += 1
 
     return allocation_size
@@ -41,16 +41,9 @@ def _get_allocated_size(cpu: Cpu, workload_map: dict, w_type: str) -> int:
 def get_oversubscribed_thread_count(cpu: Cpu, workload_map: dict) -> int:
     oversubscribed_thread_count = 0
     for t in cpu.get_threads():
-        if _is_thread_occupied(t, workload_map, BURST) and _is_thread_occupied(t, workload_map, STATIC):
+        if is_thread_occupied(t, workload_map, BURST) and is_thread_occupied(t, workload_map, STATIC):
             oversubscribed_thread_count += 1
 
     return oversubscribed_thread_count
 
 
-def _is_thread_occupied(thread: Thread, workload_map: dict, w_type: str) -> bool:
-    for w_id in thread.get_workload_ids():
-        if w_id in workload_map:
-            if workload_map[w_id].get_type() == w_type:
-                return True
-
-    return False

--- a/titus_isolate/isolate/workload_manager.py
+++ b/titus_isolate/isolate/workload_manager.py
@@ -127,7 +127,7 @@ class WorkloadManager(MetricsReporter):
     def __apply_cpuset_updates(self, old_cpu, new_cpu):
         updates = get_updates(old_cpu, new_cpu)
         for workload_id, thread_ids in updates.items():
-            log.info("updating workload: '{}' to '{}'".format(workload_id, thread_ids))
+            log.info("updating workload: '{}' to {} threads: {}".format(workload_id, len(thread_ids), thread_ids))
             self.__cgroup_manager.set_cpuset(workload_id, thread_ids)
 
         return len(updates) > 0

--- a/titus_isolate/model/utils.py
+++ b/titus_isolate/model/utils.py
@@ -38,6 +38,15 @@ def get_workload_from_event(event):
         workload_type=workload_type)
 
 
+def is_thread_occupied(thread: Thread, workload_map: dict, w_type: str) -> bool:
+    for w_id in thread.get_workload_ids():
+        if w_id in workload_map:
+            if workload_map[w_id].get_type() == w_type:
+                return True
+
+    return False
+
+
 def get_burst_workloads(workloads):
     return get_workloads_by_type(workloads, BURST)
 


### PR DESCRIPTION
A thread can be safely claimed for the burst pool if the other thread is either empty or also claimed for the burst pool already.