### PR TITLE
Restart titus-isolate always regardless of Docker failures

### DIFF
--- a/release/titus-isolate.service
+++ b/release/titus-isolate.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Titus container isolation
-After=docker.service
-Requires=docker.service
+Wants=docker.service
 
 [Service]
 EnvironmentFile=/run/titus.env
 Environment=PYTHONPATH=/usr/share/python/titus-isolate/lib/python3.5/site-packages:/usr/lib/python3/dist-packages/
+ExecStartPre=/bin/systemctl is-active docker
 ExecStartPre=/usr/share/python/titus-isolate/bin/pip3 install 'netflix-spectator-pyconf'
 ExecStart=/usr/share/python/titus-isolate/bin/titus-isolate --admin-port 7500
 KillMode=mixed


### PR DESCRIPTION
See systemd issue:
https://github.com/systemd/systemd/issues/1312