### PR TITLE
Specify gunicorn worker-tmp-dir to force in-memory heartbeat

### DIFF
--- a/docker/solver/Dockerfile
+++ b/docker/solver/Dockerfile
@@ -30,4 +30,4 @@ ENV GUROBI_HOME="/opt/gurobi810/linux64"
 ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/gurobi810/linux64/bin"
 ENV LD_LIBRARY_PATH="/opt/gurobi811/linux64/lib"
 
-CMD gunicorn -w $TITUS_NUM_CPU -b $EC2_LOCAL_IPV4:80 --log-level=info titus_isolate.api.solve:app
+CMD gunicorn -w $TITUS_NUM_CPU -b $EC2_LOCAL_IPV4:80 --log-level=info --worker-tmp-dir /dev/shm titus_isolate.api.solve:app


### PR DESCRIPTION
See [this](https://pythonspeed.com/articles/gunicorn-in-docker/)