### PR TITLE
Allow reuse of socket port to avoid contention with serial console

### DIFF
--- a/release/titus-isolate.socket
+++ b/release/titus-isolate.socket
@@ -4,8 +4,9 @@ PartOf=titus-isolate.service
 
 [Socket]
 ListenStream=127.0.0.1:7500
-Accept=no
 Backlog=64
+Accept=no
+ReusePort=yes
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
```
$ systemctl status serial-getty@ttyS0.service
● serial-getty@ttyS0.service - Serial Getty on ttyS0
   Loaded: loaded (/lib/systemd/system/serial-getty@.service; disabled; vendor preset: enabled)
   Active: active (running) since Mon 2019-06-03 22:21:51 UTC; 30min ago
     Docs: man:agetty(8)
           man:systemd-getty-generator(8)
           http://0pointer.de/blog/projects/serial-console.html
 Main PID: 1812 (agetty)
   CGroup: /system.slice/system-serial\x2dgetty.slice/serial-getty@ttyS0.service
           └─1812 /sbin/agetty --keep-baud 115200 38400 9600 ttyS0 vt220

Jun 03 22:21:51 titusagent-dev08cell001-r416xlarge003-i-090e98cfdf2530ad8 systemd[1]: Started Serial Getty on ttyS0.
```
This `serial-getty` service (no matter what port you choose) for some reason grabs the same port as the titus-isolate.socket just as it is wanted.  Allowing reuse of the same port avoids this behavior.  This only happens on boot.  Starting titus-isolate.service or titus-isolate.socket at any other time manually works fine.