### PR TITLE
Remove ambiguity about types for numpy

### DIFF
--- a/titus_isolate/monitor/workload_perf_mon.py
+++ b/titus_isolate/monitor/workload_perf_mon.py
@@ -1,6 +1,6 @@
 import calendar
 import collections
-from datetime import datetime as dt, timedelta as td
+from datetime import datetime as dt
 from math import ceil
 from threading import Lock
 
@@ -25,7 +25,9 @@ class WorkloadPerformanceMonitor:
 
     def get_buffers(self):
         with self.__buffer_lock:
-            return calendar.timegm(dt.utcnow().timetuple()), [calendar.timegm(t.timetuple()) for t in self.__timestamps], [list(e) for e in self.__buffers]
+            return calendar.timegm(dt.utcnow().timetuple()), \
+                   np.array([calendar.timegm(t.timetuple()) for t in self.__timestamps], dtype=np.float32), \
+                   [list(e) for e in self.__buffers]
     
     def get_normalized_cpu_usage_last_seconds(self, seconds, agg_granularity_secs=60):
         num_buckets = ceil(seconds / agg_granularity_secs)


### PR DESCRIPTION
Stack trace:
```
Failed to execute func: __add_workload on workload: cd242f10-6c78-4c29-8806-1168def39ee8
                       Traceback (most recent call last):
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 56, in _wrapfunc
                           return getattr(obj, method)(*args, **kwds)
                       AttributeError: 'list' object has no attribute 'searchsorted'

                       During handling of the above exception, another exception occurred:

                       Traceback (most recent call last):
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/isolate/workload_manager.py", line 80, in __update_workload
                           func(arg)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/isolate/workload_manager.py", line 97, in __add_workload
                           request = self.__get_threads_request(workload.get_id(), workload_map, "assign")
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/isolate/workload_manager.py", line 158, in __get_threads_request
                           self.__get_cpu_usage(),
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/isolate/workload_manager.py", line 151, in __get_cpu_usage
                           return self.__wmm.get_cpu_usage(seconds=3600, agg_granularity_secs=60)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/monitor/workload_monitor_manager.py", line 31, in get_cpu_usage
                           cpu_usage[workload_id] = monitor.get_normalized_cpu_usage_last_seconds(seconds, agg_granularity_secs)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/monitor/workload_perf_mon.py", line 34, in get_normalized_cpu_usage_last_seconds
                           return WorkloadPerformanceMonitor.normalize_data(*self.get_buffers(), num_buckets, agg_granularity_secs)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/titus_isolate/monitor/workload_perf_mon.py", line 64, in normalize_data
                           slice_ts_min = np.searchsorted(timestamps, ts_min)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 1246, in searchsorted
                           return _wrapfunc(a, 'searchsorted', v, side=side, sorter=sorter)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 66, in _wrapfunc
                           return _wrapit(obj, method, *args, **kwds)
                         File "/opt/venvs/titus-isolate/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 46, in _wrapit
                           result = getattr(asarray(obj), method)(*args, **kwds)
                         File "/usr/lib/python3/dist-packages/gunicorn/workers/base.py", line 192, in handle_abort
                           sys.exit(1)
                       SystemExit: 1
```

Looks like this is a result of [typecasting confusion in numpy](https://stackoverflow.com/a/46760597).

The fix is to provide an appropriate type to numpy.