### PR TITLE
Add an after requirement to avoid crash loop at machine start

### DIFF
--- a/release/titus-isolate.service
+++ b/release/titus-isolate.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Titus container isolation
 Wants=docker.service
+After=docker.service
 Requires=titus-isolate.socket
 
 [Service]


### PR DESCRIPTION
At least attempt to wait for Docker to be ready before starting