### PR TITLE
Fix usage trimming

### DIFF
--- a/titus_isolate/predict/resource_usage_predictor.py
+++ b/titus_isolate/predict/resource_usage_predictor.py
@@ -91,7 +91,7 @@ class ResourceUsagePredictor(SimpleCpuPredictor):
     def __translate_usage(usages: Dict[str, List[float]]) -> dict:
         out_usage = {}
         for resource_name, values in usages.items():
-            out_usage[RESOURCE_HEADING_MAPPINGS[resource_name]] = values[:60]
+            out_usage[RESOURCE_HEADING_MAPPINGS[resource_name]] = values[-60:]
 
         return out_usage
 


### PR DESCRIPTION
Get the last 60 elements of the list, not the first 60 elements.  We
want to discard the oldest usage elements, not the most recent