### PR TITLE
Always publish resource usage prediction windows

### DIFF
--- a/titus_isolate/crd/model/resource_usage_prediction.py
+++ b/titus_isolate/crd/model/resource_usage_prediction.py
@@ -159,11 +159,13 @@ class ResourceUsagePredictions:
         self.model_instance_id = raw.get(MODEL_INSTANCE_ID, "UNKNOWN_MODEL_INSTANCE_ID")
         self.prediction_ts_ms = int(raw.get(PREDICTION_TS_MS, '0'))
         self.metadata = raw.get(META_DATA, {})
-
         self.__predictions = {}
-        for p in raw.get(PREDICTIONS, {}):
-            job_id = p.get(JOB_ID, "UNKNOWN_JOB_ID")
-            self.__predictions[job_id] = ResourceUsagePrediction(p)
+
+        preds = raw.get(PREDICTIONS)
+        if preds is not None:
+            for p in preds:
+                job_id = p.get(JOB_ID, "UNKNOWN_JOB_ID")
+                self.__predictions[job_id] = ResourceUsagePrediction(p)
 
     @property
     def predictions(self):
@@ -218,7 +220,7 @@ class CondensedResourceUsagePrediction:
     @staticmethod
     def __condense_predictions(predictions: List[ResourceUsagePrediction]) -> ResourceUsagePrediction:
         if len(predictions) < 1:
-            raise Exception("At least one prediction must exist in order to be condensed")
+            return ResourceUsagePrediction({})
 
         out = predictions[0]
         for i in range(1, len(predictions)):

--- a/titus_isolate/event/oversubscribe_event_handler.py
+++ b/titus_isolate/event/oversubscribe_event_handler.py
@@ -78,6 +78,10 @@ class OversubscribeEventHandler(EventHandler, MetricsReporter):
             return {}
 
         workloads = self.__workload_manager.get_workloads()
+        if len(workloads) == 0:
+            log.warning("No workloads, skipping cpu usage prediction")
+            return {}
+
         resource_usage = self.__workload_monitor_manager.get_resource_usage()
 
         log.info("Getting simple cpu predictions...")


### PR DESCRIPTION
Even when no workloads are present we should publish an empty resource
usage prediction