### PR TITLE
Make the systemd unit depend on the vk-config service

### DIFF
--- a/release/titus-isolate.service
+++ b/release/titus-isolate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Titus container isolation
-Wants=docker.service titus-kube-config.service
-After=docker.service titus-kube-config.service
+Wants=docker.service titus-kube-config.service virtual-kubelet-config.service
+After=docker.service titus-kube-config.service virtual-kubelet-config.service
 Requires=titus-isolate.socket
 
 [Service]


### PR DESCRIPTION
The titus-isolate systemd unit depends on the /run/virtual-kubelet.config
environment file. This file is generated by virtual-kubelet-config.service,
so we should Want/After that service as well.

This currently still works on virtual-kubelet and kubelet.