### PR TITLE
Yield to other threads when processing events.

### DIFF
--- a/titus_isolate/event/event_manager.py
+++ b/titus_isolate/event/event_manager.py
@@ -109,6 +109,7 @@ class EventManager(MetricsReporter):
     def __pull_events(self):
         for event in self.__events:
             self.__put_event(event)
+            time.sleep(0)
 
     def __put_event(self, event):
         event = json.loads(event.decode("utf-8"))
@@ -144,6 +145,7 @@ class EventManager(MetricsReporter):
                         type(event_handler).__name__, event))
                     self.__report_failed_event(event_handler)
 
+            time.sleep(0)
             self.__q.task_done()
             self.__reg.counter(EVENT_PROCESSED_KEY, self.__tags).increment()
             self.__reg.gauge(QUEUE_DEPTH_KEY, self.__tags).set(self.get_queue_depth())


### PR DESCRIPTION
When titus-isolate crashes, and comes up with a large backlog of
events, it can take a long time for it to process all the events.
System startup timer can expire in this period, causing a restart
loop.

This should yield the thread, and allow the systemd notification
to be processed when such a backlog occurs.