### PR TITLE
Stop depending on docker.service at startup.

### DIFF
--- a/release/titus-isolate.service
+++ b/release/titus-isolate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Titus container isolation
-Wants=docker.service titus-kube-config.service virtual-kubelet-config.service
-After=docker.service titus-kube-config.service virtual-kubelet-config.service
+Wants=titus-kube-config.service virtual-kubelet-config.service
+After=titus-kube-config.service virtual-kubelet-config.service
 Requires=titus-isolate.socket
 
 [Service]


### PR DESCRIPTION
Since we do not enable docker on the kubelet node any more, stop
depending on docker.service to start titus-isolate.