### PR TITLE
Update the TASK_ID constant to reflect the newer style docker label

### DIFF
--- a/titus_isolate/event/constants.py
+++ b/titus_isolate/event/constants.py
@@ -1,5 +1,8 @@
 import json
 
+# Docker Event constants. You can see these in action by watching
+# docker events --format '{{json .}}'
+# on a titus agent as containers start
 ACTION = "Action"
 ACTOR = "Actor"
 ATTRIBUTES = "Attributes"
@@ -9,9 +12,10 @@ NAME = "name"
 REPO_DIGESTS = 'RepoDigests'
 TIME = "time"
 TYPE = "Type"
-TASK_ID = "TITUS_TASK_INSTANCE_ID"
-
 CONTAINER = "container"
+# The above are stock docker string constants, the below are custom docker labels (attributes)
+# set by the titus executor
+TASK_ID = "titus.task_id"
 
 # Handled Actions
 # Docker


### PR DESCRIPTION
I removed the older style label, not thinking it was used by anyone.
This was where it was used!

Here is an event on a real agent (running older code with both old and new labels): 
```
{
  "status": "start",
  "id": "7f8af142dca09f472d3447b83dc9a9b848530b52e43acb68d69dc0f9337503b8",
  "from": "registry.us-east-1.streamingtest.titus.netflix.net:7002/titusops/echoservice@sha256:60d5cdeea0de265fe7b5fe40fe23a90e1001181312d226d0e688b0f75045109e",
  "Type": "container",
  "Action": "start",
  "Actor": {
    "ID": "7f8af142dca09f472d3447b83dc9a9b848530b52e43acb68d69dc0f9337503b8",
    "Attributes": {
      "TITUS_TASK_INSTANCE_ID": "2aa1631c-d037-459f-b012-3c62e19f3136",
      "com.netflix.titus.appName": "kyleatestapp",
      "com.netflix.titus.command": "/bin/sh -c date; echo hi; echo im inside the container. sleeping forever; sleep infinity",
      "com.netflix.titus.cpu": "1",
      "com.netflix.titus.disk": "10000",
      "com.netflix.titus.job.type": "SERVICE",
      "com.netflix.titus.mem": "512",
      "com.netflix.titus.network": "128",
      "com.netflix.titus.owner.email": "kylea@netflix.com",
      "com.netflix.titus.workload.type": "static",
      "ec2.iam.role": "arn:aws:iam::179727101194:role/TitusContainerDefaultRole",
      "image": "registry.us-east-1.streamingtest.titus.netflix.net:7002/titusops/echoservice@sha256:60d5cdeea0de265fe7b5fe40fe23a90e1001181312d226d0e688b0f75045109e",
      "name": "2aa1631c-d037-459f-b012-3c62e19f3136",
      "titus.executor.pid": "4081058",
      "titus.net.ipv4": "100.122.100.27",
      "titus.task_id": "2aa1631c-d037-459f-b012-3c62e19f3136",
      "titus.vpc.ipv4": "100.122.100.27"
    }
  },
  "scope": "local",
  "time": 1647018233,
  "timeNano": 1647018233708686300
}

```