### PR TITLE
Avoid installing specator pyconf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ kubernetes==21.7.0
 lightgbm==2.2.3
 MarkupSafe==2.0.1
 netflix-spectator-py==0.1.17
-netflix-spectator-pyconf
 numpy==1.19.4
 oauthlib==3.2.0
 osqp==0.6.2.post5


### PR DESCRIPTION
We prefer the runtime installed version