### PR TITLE
Add cpu_viz endpoint to print out cpu diagrams.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ $ curl -s localhost:5555/cpu | jq
 }
 ```
 
+```
+GET /cpu_viz
+```
+This endpoint prints out a human readable ascii cpu diagram with the current tasks.
+```bash
+$ curl -s localhost:5555/cpu_viz
+| a | a | a | a |   a: ['burst0_4', 'burst1_4']
+| a | a | a | a |   b: ['static_2']
+| ------------- |
+| a | a | b | b |
+| a | a |   |   |
+```
+
 ### Violations
 ```
 GET /violations

--- a/titus_isolate/api/status.py
+++ b/titus_isolate/api/status.py
@@ -36,6 +36,7 @@ from titus_isolate.utils import get_config_manager, get_workload_manager, \
     set_event_log_manager, start_periodic_scheduling, set_cpu_usage_predictor_manager, \
     set_workload_monitor_manager, set_workload_manager, set_event_manager, set_pod_manager, is_running_on_agent, \
     get_pod_manager
+from titus_isolate.model.processor import utils
 
 app = Flask(__name__)
 
@@ -86,6 +87,11 @@ def get_isolated_workload_ids():
 @app.route('/cpu')
 def get_cpu():
     return json.dumps(get_workload_manager().get_cpu().to_dict())
+
+
+@app.route('/cpu_viz')
+def get_cpu_viz():
+    return utils.visualize(get_workload_manager().get_cpu())
 
 
 @app.route('/violations')


### PR DESCRIPTION
This adds a /cpu_viz endpoint that prints out cpu diagrams as in the README.